### PR TITLE
Log everything under /var/log/funsize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ COPY / /app
 COPY configs/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 RUN mkdir -p /perma/tools /var/log/funsize /var/cache/funsize
-RUN chmod 777 /var/log/funsize
-RUN chown daemon /var/cache/funsize
+RUN chown daemon /var/cache/funsize /var/log/funsize
 
 # TODO: publish the tools as a separate tarball?
 ADD https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-central/mar-tools/linux64/mar /perma/tools/
@@ -32,5 +31,4 @@ RUN /venv/bin/pip install gunicorn==19.1.1
 RUN /venv/bin/python setup.py develop
 
 WORKDIR /
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["/usr/bin/supervisord"]

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -4,5 +4,5 @@
     "Name": "ubuntu:trusty",
     "Update": "true"
   },
-  "Logging": "/var/log"
+  "Logging": "/var/log/funsize"
 }

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,5 @@
 - [ ] Upload individual patches from the HOOK async?
 - [ ] Less of deffensive programming practices (DownloadError)
 - [ ] Auth
-- [ ] Separate app and request logs
 - [ ] Use better HTTP codes
 - [ ] use send_file() to stream files instead of reading them into memory

--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/var/log/funsize/supervisord.log
+childlogdir=/var/log/funsize
 
 [program:celery]
 command=/venv/bin/celery worker -f /var/log/funsize/celery.log --uid daemon -l INFO -A funsize.backend.tasks --config %(ENV_FUNSIZE_CELERY_CONFIG)s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mkdir -p /var/log/supervisor /var/log/funsize
-chmod 777 /var/log/funsize
-exec "$@"


### PR DESCRIPTION
This change allows Elastic Beanstalk to snapshot the logs inside containers. 